### PR TITLE
Decrease GPU memory usage

### DIFF
--- a/demo.py
+++ b/demo.py
@@ -137,7 +137,8 @@ class Demo:
     def run_single_frame(self, frame_id):
         node_pos, curr_motion, historical_motion, edge_indices, down_sample_indices, up_sample_indices = self.preprocess(frame_id)
 
-        outputs = self.model(node_pos, curr_motion, historical_motion, edge_indices,down_sample_indices, up_sample_indices)
+        with torch.no_grad():
+            outputs = self.model(node_pos, curr_motion, historical_motion, edge_indices,down_sample_indices, up_sample_indices)
         outputs = outputs.detach().cpu().numpy()
         mu = outputs[:, :3]
         sigma = outputs[:, -1]


### PR DESCRIPTION
There were issues regarding the high memory usage. I couldn't run the demo myself due to CUDA out-of-memory errors.

The solution is to avoid computing gradients at the forward step. As it was before, the gradients accumulate at each iteration since they are not used. This results in linearly increasing memory usage to store unnecessary tensors.